### PR TITLE
Fix conditional display of Apple Pay in Preview Cart

### DIFF
--- a/assets/scss/components/stencil/applePay/_applePay.scss
+++ b/assets/scss/components/stencil/applePay/_applePay.scss
@@ -40,8 +40,14 @@
 
 .previewCartCheckout {
     .apple-pay-checkout-button {
-        display: inline-block;
         float: none;
         margin-top: spacing("half");
     }
 }
+
+.apple-pay-supported .previewCartCheckout {
+    .apple-pay-checkout-button {
+        display: inline-block;
+    }
+}
+


### PR DESCRIPTION
#### What?

Inline block display for preview cart button styling overrode conditional display of Apple Pay button and resulted in an empty button when Apple Pay was not available. Applied conditional rules used from cart styling to preview cart.

#### Tickets / Documentation

N/A

#### Screenshots (if appropriate)

![before](https://user-images.githubusercontent.com/950448/114443403-a4ad7780-9b9b-11eb-9429-a203717452fd.png)

![after](https://user-images.githubusercontent.com/950448/114443402-a4ad7780-9b9b-11eb-8444-f7f601abb8f7.png)

