### PR TITLE
Update product-info.html

### DIFF
--- a/templates/components/products/product-info.html
+++ b/templates/components/products/product-info.html
@@ -2,4 +2,4 @@
 {{name}}, {{> components/products/product-aria-label}}
 {{else}}
 {{name}}
-{{/or}}"
+{{/or}}


### PR DESCRIPTION
#### What?

Both a leading and trailing quote are already present in the code that calls this template, so this trailing " breaks the HTML. If you look at the source in the demo theme you'll see this behavior https://cornerstone-light-demo.mybigcommerce.com/shop-all/garden/

#### Requirements

- [ ] CHANGELOG.md entry added (required for code changes only)

#### Tickets / Documentation

Add links to any relevant tickets and documentation.

- [Link 1](http://example.com)
- ...

#### Screenshots (if appropriate)

![image](https://github.com/minutiae/cornerstone/assets/950448/a507acec-e417-4ec4-995c-b18255820ce3)
